### PR TITLE
build: Improve wget command for neovim download in setup.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -24,7 +24,7 @@ if ! isInstalled wget; then
 	nala install nginx -y
 fi
 
-if ! wget https://github.com/neovim/neovim/releases/latest/download/nvim-linux64.tar.gz; then
+if ! wget https://github.com/neovim/neovim/releases/latest/download/nvim-linux64.tar.gz -q; then
 	echo "failed to download nvim"
 	exit 1
 fi

--- a/setup.sh
+++ b/setup.sh
@@ -24,6 +24,7 @@ if ! isInstalled wget; then
 	nala install nginx -y
 fi
 
+echo "downloading nvim"
 if ! wget https://github.com/neovim/neovim/releases/latest/download/nvim-linux64.tar.gz -q; then
 	echo "failed to download nvim"
 	exit 1


### PR DESCRIPTION
Add the "-q" flag to the wget command to silence output during the download
process in setup.sh. This enhances user experience by reducing unnecessary
output.